### PR TITLE
style: display toolbar on top of settings fields

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -18,6 +18,7 @@ export function Toolbar({ drawerWidth }: { drawerWidth: number }) {
         px: 2,
         backgroundColor: theme.palette.background.paper,
         borderTop: `2px solid ${theme.palette.divider}`,
+        zIndex: 1,
       }}
     >
       <MinerSummary />


### PR DESCRIPTION
Partially addresses #1 by setting an explicit z-index on the bottom toolbar so that it is not inadvertently displayed behind text field labels on the settings page.